### PR TITLE
Default UIscale value update.

### DIFF
--- a/Engine/Source/Runtime/Tools/UI/ImGui/ImGuiRenderer.cpp
+++ b/Engine/Source/Runtime/Tools/UI/ImGui/ImGuiRenderer.cpp
@@ -143,6 +143,9 @@ namespace Lumina
                 Scale *= ResolutionFactor(static_cast<float>(Window->GetMonitorResolution().y));
             }
             Scale = (Scale > 0.0f ? Scale : 1.0f) * kAutoScaleBias;
+        	
+        	GetMutableDefault<CEditorSettings>()->UIScale = Scale;
+        	
             return std::max(Scale, 0.5f);
         }
 


### PR DESCRIPTION
Set the UIScale in ImGuiRenderer.cpp when it is resolved so that the + or - buttons work off of the default value. This avoids a user pressing the + sign when it is set to 0, and ending up with a 0.01 ui scale.