### PR TITLE
anim graph transition fixes, time-in-state source

### DIFF
--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimStateMachineGraph.cpp
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimStateMachineGraph.cpp
@@ -100,12 +100,14 @@ namespace Lumina
 
     FString CAnimStateTransition::GetConditionText() const
     {
-        if (ConditionParameter.IsNone())
+        const bool bTimeInState = ConditionSource == EAnimTransitionSource::TimeInState;
+        if (!bTimeInState && ConditionParameter.IsNone())
         {
             return FString("Always");
         }
 
-        return Format("{} {} {}", ConditionParameter.c_str(), SM::CompareSymbol(Compare), CompareValue);
+        const char* Source = bTimeInState ? "TimeInState" : ConditionParameter.c_str();
+        return Format("{} {} {}", Source, SM::CompareSymbol(Compare), CompareValue);
     }
 
     void CAnimStateMachineGraph::EnsureSetup()

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimStateTransition.h
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimStateTransition.h
@@ -22,6 +22,11 @@ namespace Lumina
         PROPERTY()
         int64 ToStateNodeID = 0;
 
+        /** What Compare Value is tested against: a graph parameter, or how long the state machine has
+         *  been in its current state. Time In State is how a play-once state hands over when it ends. */
+        PROPERTY(Editable, Category = "Transition")
+        EAnimTransitionSource ConditionSource = EAnimTransitionSource::Parameter;
+
         /** Graph parameter compared against Compare Value to gate the transition.
          *  Leave empty for an unconditional / always-true transition. */
         PROPERTY(Editable, Category = "Transition", ParameterPicker)

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphCompiler.h
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphCompiler.h
@@ -66,6 +66,16 @@ namespace Lumina
         uint16 AllocObjectReg() { return NextObjectReg++; }
         uint16 AllocStateSlot() { return NextStateSlot++; }
 
+        // Only clocks may be wound back while inactive; zeroing a nested machine's bookkeeping thrashes it.
+        uint16 AllocClockSlot()
+        {
+            const uint16 Slot = NextStateSlot++;
+            ClockSlots.push_back(Slot);
+            return Slot;
+        }
+
+        const TVector<uint16>& GetClockSlots() const { return ClockSlots; }
+
         // Value-producing emitters return the destination register they allocated; callers thread that
         // index into downstream emitters.
         uint16 EmitLoadConst(float Value);
@@ -225,6 +235,8 @@ namespace Lumina
         uint16 NextPoseReg   = 0;
         uint16 NextObjectReg = 0;
         uint16 NextStateSlot = 0;
+
+        TVector<uint16> ClockSlots;
 
         bool bEmittedOutput = false;
     };

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_BlendSpace.cpp
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_BlendSpace.cpp
@@ -42,7 +42,7 @@ namespace Lumina
 
         const uint16 BlendSpaceIndex = bDynamicBlendSpace ? (uint16)BlendSpaceObjectReg
                                                           : Compiler.AddBlendSpace(BlendSpace.Get());
-        const uint16 PhaseSlot       = Compiler.AllocStateSlot();
+        const uint16 PhaseSlot       = Compiler.AllocClockSlot();
 
         const uint16 XReg     = ResolveValueInput(XPin, Compiler);
         const uint16 SpeedReg = ResolveValueInput(SpeedPin, Compiler);

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_ClipPlayer.cpp
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_ClipPlayer.cpp
@@ -34,7 +34,7 @@ namespace Lumina
         }
 
         const uint16 ClipIndex = bDynamicClip ? (uint16)ClipObjectReg : Compiler.AddClip(Clip.Get());
-        const uint16 StateSlot = Compiler.AllocStateSlot();
+        const uint16 StateSlot = Compiler.AllocClockSlot();
         const uint16 SpeedReg  = ResolveValueInput(SpeedPin, Compiler);
 
         // Loop mode is register-driven so it can be wired; an unconnected pin

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_StateMachine.cpp
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_StateMachine.cpp
@@ -114,6 +114,9 @@ namespace Lumina
         THashSet<int64> AnyStateNodeIDs;
         TVector<TPair<CEdGraphNode*, int32>> StateNodesForDebug;
 
+        // Machine-relative: a nested machine appended to the same list, and those entries belong to its owner.
+        const uint16 MachineClockFirst = (uint16)Compiler.GetClockSlots().size();
+
         for (CEdGraphNode* Node : SMGraph->Nodes)
         {
             if (Node->IsA<CAnimGraphNode_StateAny>())
@@ -129,6 +132,8 @@ namespace Lumina
 
             CAnimationGraphNodeGraph* BlendTree = StateNode->GetOrCreateBlendTree();
 
+            const uint16 ClockSlotFirst = (uint16)Compiler.GetClockSlots().size() - MachineClockFirst;
+
             uint16 PoseReg = 0;
             if (!BlendTree->CompileNodes(Compiler, PoseReg))
             {
@@ -139,9 +144,14 @@ namespace Lumina
 
             const int32 StateIndex = (int32)StateMachine.StatePoseRegisters.size();
             StateMachine.StatePoseRegisters.push_back(PoseReg);
+            StateMachine.StateClockSlotFirst.push_back(ClockSlotFirst);
+            StateMachine.StateClockSlotEnd.push_back((uint16)Compiler.GetClockSlots().size() - MachineClockFirst);
             NodeIDToStateIndex[StateNode->GetNodeID()] = StateIndex;
             StateNodesForDebug.emplace_back(StateNode, StateIndex);
         }
+
+        const TVector<uint16>& CompiledClockSlots = Compiler.GetClockSlots();
+        StateMachine.ClockSlots.assign(CompiledClockSlots.begin() + MachineClockFirst, CompiledClockSlots.end());
 
         if (StateMachine.StatePoseRegisters.empty())
         {
@@ -237,6 +247,7 @@ namespace Lumina
             FAnimGraphTransition Runtime;
             Runtime.FromState          = FromIndex;
             Runtime.ToState            = ToIt->second;
+            Runtime.ConditionSource    = Transition->ConditionSource;
             Runtime.ConditionParameter = Transition->ConditionParameter;
             Runtime.Compare            = Transition->Compare;
             Runtime.CompareValue       = Transition->CompareValue;
@@ -245,8 +256,11 @@ namespace Lumina
 
             // Make sure the condition parameter exists in the compiled table,
             // and warn if it doesn't match a blackboard key (renamed / retyped).
-            Compiler.ValidateParameterKey(Transition->ConditionParameter, this);
-            Compiler.AddParameter(Transition->ConditionParameter, EAnimGraphParamType::Float, 0.0f);
+            if (Runtime.ConditionSource == EAnimTransitionSource::Parameter)
+            {
+                Compiler.ValidateParameterKey(Transition->ConditionParameter, this);
+                Compiler.AddParameter(Transition->ConditionParameter, EAnimGraphParamType::Float, 0.0f);
+            }
 
             StateMachine.Transitions.push_back(Runtime);
         }
@@ -256,7 +270,7 @@ namespace Lumina
         const uint16 FromStateSlot    = Compiler.AllocStateSlot();
         StateMachine.CurrentStateSlot = CurrentStateSlot;
         StateMachine.FromStateSlot    = FromStateSlot;
-        StateMachine.TimerSlot        = Compiler.AllocStateSlot();
+        StateMachine.TimeInStateSlot  = Compiler.AllocStateSlot();
         StateMachine.DurationSlot     = Compiler.AllocStateSlot();
 
         const uint16 ResultReg    = Compiler.EmitEvalStateMachine(Move(StateMachine));

--- a/Engine/Source/Runtime/Source/Animation/AnimationGraphVM.cpp
+++ b/Engine/Source/Runtime/Source/Animation/AnimationGraphVM.cpp
@@ -49,15 +49,25 @@ namespace Lumina
 
         static FORCEINLINE bool EvalTransitionCondition(const FAnimGraphTransition& Transition,
                                                         const CAnimationGraph* Graph,
-                                                        const TVector<float>& Parameters)
+                                                        const TVector<float>& Parameters,
+                                                        float TimeInState)
         {
-            // Resolved at load/compile; the fallback covers graphs built outside those paths.
-            const int32 ParamIdx = Transition.CachedParamIndex != FAnimGraphTransition::ParamUnresolved
-                ? Transition.CachedParamIndex
-                : Graph->FindParameterIndex(Transition.ConditionParameter);
-            const float Value = (ParamIdx >= 0 && ParamIdx < (int32)Parameters.size())
-                ? Parameters[ParamIdx]
-                : 0.0f;
+            float Value = TimeInState;
+            if (Transition.ConditionSource == EAnimTransitionSource::Parameter)
+            {
+                // Resolved at load/compile; the fallback covers graphs built outside those paths.
+                int32 ParamIdx = Transition.CachedParamIndex;
+                if (ParamIdx == FAnimGraphTransition::ParamUnresolved)
+                {
+                    ParamIdx = Graph->FindParameterIndex(Transition.ConditionParameter);
+                }
+
+                Value = 0.0f;
+                if (ParamIdx >= 0 && ParamIdx < (int32)Parameters.size())
+                {
+                    Value = Parameters[ParamIdx];
+                }
+            }
 
             switch (Transition.Compare)
             {
@@ -1076,7 +1086,7 @@ namespace Lumina
                 }
 
                 // Out-of-range slot = corrupt/version-mismatched bytecode; fall back to bind pose.
-                if (SM.CurrentStateSlot >= NumState || SM.FromStateSlot >= NumState ||
+                if (SM.CurrentStateSlot >= NumState || SM.FromStateSlot >= NumState || SM.TimeInStateSlot >= NumState ||
                     SmIdx >= State.Inertializers.size())
                 {
                     SetPoseTask(Dst, OutTasks.Add(RefTask));
@@ -1109,7 +1119,7 @@ namespace Lumina
                     {
                         continue;
                     }
-                    if (Detail::EvalTransitionCondition(Transition, Graph, State.Parameters))
+                    if (Detail::EvalTransitionCondition(Transition, Graph, State.Parameters, State.StateSlots[SM.TimeInStateSlot]))
                     {
                         From           = Current;
                         Current        = Transition.ToState;
@@ -1174,8 +1184,30 @@ namespace Lumina
                     }
                 }
 
-                State.StateSlots[SM.CurrentStateSlot] = (float)Current;
-                State.StateSlots[SM.FromStateSlot]    = (float)From;
+                State.StateSlots[SM.CurrentStateSlot]  = (float)Current;
+                State.StateSlots[SM.FromStateSlot]     = (float)From;
+                State.StateSlots[SM.TimeInStateSlot]   = bStart ? 0.0f : State.StateSlots[SM.TimeInStateSlot] + DeltaTime;
+
+                // Clocks advance whether or not the state is active, so a finished play-once never replays.
+                const int32 NumClockRanges = (int32)Math::Min(SM.StateClockSlotFirst.size(), SM.StateClockSlotEnd.size());
+                const uint16 NumClockSlots = (uint16)SM.ClockSlots.size();
+                for (int32 StateIndex = 0; StateIndex < NumStates && StateIndex < NumClockRanges; ++StateIndex)
+                {
+                    if (StateIndex == Current)
+                    {
+                        continue;
+                    }
+
+                    const uint16 RangeEnd = Math::Min(SM.StateClockSlotEnd[StateIndex], NumClockSlots);
+                    for (uint16 Index = SM.StateClockSlotFirst[StateIndex]; Index < RangeEnd; ++Index)
+                    {
+                        const uint16 Slot = SM.ClockSlots[Index];
+                        if (Slot < NumState)
+                        {
+                            State.StateSlots[Slot] = 0.0f;
+                        }
+                    }
+                }
                 break;
             }
 

--- a/Engine/Source/Runtime/Source/Animation/TaskSystem/AnimTaskExecutor.cpp
+++ b/Engine/Source/Runtime/Source/Animation/TaskSystem/AnimTaskExecutor.cpp
@@ -135,7 +135,12 @@ namespace Lumina
                     float V0 = 0.0f;
                     if (InvDt > 0.0f)
                     {
-                        const FQuat Qp = Math::Normalize(SourcePrev.Rotations[i] * Math::Inverse(Target.Rotations[i]));
+                        FQuat Qp = Math::Normalize(SourcePrev.Rotations[i] * Math::Inverse(Target.Rotations[i]));
+                        if (Qp.w < 0.0f)
+                        {
+                            // Same shortest arc as X0; a full turn out here is fake velocity.
+                            Qp = Qp * -1.0f;
+                        }
                         V0 = (X0 - QuatAngleAbout(Qp, Axis)) * InvDt;
                     }
                     In.Rot[i] = FInertChannel{ Axis, X0, V0 };

--- a/Engine/Source/Runtime/Source/Assets/AssetTypes/Animation/AnimationGraph/AnimationGraph.h
+++ b/Engine/Source/Runtime/Source/Assets/AssetTypes/Animation/AnimationGraph/AnimationGraph.h
@@ -31,6 +31,17 @@ namespace Lumina
         NotEqual,
     };
 
+    // Where a transition's left-hand value comes from.
+    REFLECT()
+    enum class EAnimTransitionSource : uint8
+    {
+        /** The graph parameter named by Condition Parameter. */
+        Parameter,
+
+        /** Seconds the state machine has spent in its current state, so a state can time itself out. */
+        TimeInState,
+    };
+
     // How the bytes at a resolved offset decode. Filled at link from the property's TypeFlags.
     enum class EAnimParamValueType : uint8
     {
@@ -134,6 +145,9 @@ namespace Lumina
         int32 FromState = -1;
         int32 ToState = 0;
 
+        // What the compare reads. ConditionParameter is ignored unless this is Parameter.
+        EAnimTransitionSource ConditionSource = EAnimTransitionSource::Parameter;
+
         // Gating parameter; an undeclared parameter evaluates as 0.
         FName ConditionParameter;
         EAnimTransitionCompare Compare = EAnimTransitionCompare::Greater;
@@ -159,6 +173,10 @@ namespace Lumina
             Ar << Data.CompareValue;
             Ar << Data.BlendDuration;
             Ar << Data.bCanInterrupt;
+            if (Ar.GetFileVersion() >= (int32)ELuminaEngineVersion::ANIM_GRAPH_STATE_CLOCKS)
+            {
+                Ar << Data.ConditionSource;
+            }
             return Ar;
         }
     };
@@ -243,11 +261,16 @@ namespace Lumina
         // Outgoing edges, checked in list order; first passing wins.
         TVector<FAnimGraphTransition> Transitions;
 
+        // Clocks only: a nested machine's bookkeeping sits in its owner's blend tree and must not be zeroed.
+        TVector<uint16> ClockSlots;
+        TVector<uint16> StateClockSlotFirst;
+        TVector<uint16> StateClockSlotEnd;
+
         // Slots into FAnimGraphVMState.StateSlots: Current/From state indices (From -1 when not
-        // transitioning), Timer elapsed, Duration of the active transition.
+        // transitioning), seconds spent in the current state, Duration of the active transition.
         uint16 CurrentStateSlot = 0;
         uint16 FromStateSlot = 0;
-        uint16 TimerSlot = 0;
+        uint16 TimeInStateSlot = 0;
         uint16 DurationSlot = 0;
 
         friend FArchive& operator << (FArchive& Ar, FAnimGraphStateMachine& Data)
@@ -257,8 +280,22 @@ namespace Lumina
             Ar << Data.Transitions;
             Ar << Data.CurrentStateSlot;
             Ar << Data.FromStateSlot;
-            Ar << Data.TimerSlot;
+            Ar << Data.TimeInStateSlot;
             Ar << Data.DurationSlot;
+            if (Ar.GetFileVersion() >= (int32)ELuminaEngineVersion::ANIM_GRAPH_STATE_CLOCK_LIST)
+            {
+                Ar << Data.ClockSlots;
+                Ar << Data.StateClockSlotFirst;
+                Ar << Data.StateClockSlotEnd;
+            }
+            else if (Ar.GetFileVersion() >= (int32)ELuminaEngineVersion::ANIM_GRAPH_STATE_CLOCKS)
+            {
+                // The interim layout's ranges addressed a different array; drop them and let a recompile refill.
+                TVector<uint16> UnusedClockSlotFirst;
+                TVector<uint16> UnusedClockSlotEnd;
+                Ar << UnusedClockSlotFirst;
+                Ar << UnusedClockSlotEnd;
+            }
             return Ar;
         }
     };

--- a/Engine/Source/Runtime/Source/Core/Versioning/CoreVersion.h
+++ b/Engine/Source/Runtime/Source/Core/Versioning/CoreVersion.h
@@ -66,6 +66,12 @@ enum class ELuminaEngineVersion : uint32
 	// FAnimationResource no longer writes its raw channels; older files still read them and compress on load.
 	ANIM_CHANNELS_DROPPED,
 
+	// FAnimGraphStateMachine serializes per-state clock ranges; FAnimGraphTransition its condition source.
+	ANIM_GRAPH_STATE_CLOCKS,
+
+	// Clock ranges index a serialized ClockSlots list, which excludes a nested machine's bookkeeping.
+	ANIM_GRAPH_STATE_CLOCK_LIST,
+
 	AUTOMATIC_VERSION_PLUS_ONE,
 	AUTOMATIC_VERSION = AUTOMATIC_VERSION_PLUS_ONE - 1
 };

--- a/Engine/Tests/Source/AnimationCurveTests.cpp
+++ b/Engine/Tests/Source/AnimationCurveTests.cpp
@@ -187,7 +187,7 @@ TEST(AnimationCurves, StateTransitionEasesCurvesAcrossTheBlend)
     Machine.StatePoseRegisters   = { IdlePose, RunPose };
     Machine.CurrentStateSlot     = Compiler.AllocStateSlot();
     Machine.FromStateSlot        = Compiler.AllocStateSlot();
-    Machine.TimerSlot            = Compiler.AllocStateSlot();
+    Machine.TimeInStateSlot      = Compiler.AllocStateSlot();
     Machine.DurationSlot         = Compiler.AllocStateSlot();
 
     FAnimGraphTransition ToRun;

--- a/Engine/Tests/Source/AnimationStateMachineTests.cpp
+++ b/Engine/Tests/Source/AnimationStateMachineTests.cpp
@@ -1,0 +1,270 @@
+﻿#include <gtest/gtest.h>
+
+#include "Animation/AnimationGraphVM.h"
+#include "Assets/AssetTypes/Animation/AnimationGraph/AnimationGraph.h"
+#include "Assets/AssetTypes/Mesh/Animation/Animation.h"
+#include "Renderer/SkeletonResource.h"
+#include "UI/Tools/NodeGraph/Animation/AnimationGraphCompiler.h"
+
+using namespace Lumina;
+
+namespace
+{
+    CAnimation* MakeStateClip(float Duration)
+    {
+        CAnimation* Clip = NewObject<CAnimation>();
+        Clip->GetAnimationResource()->Duration = Duration;
+        return Clip;
+    }
+
+    void MakeOneBoneSkeleton(FSkeletonResource& Skeleton)
+    {
+        FSkeletonResource::FBoneInfo Bone;
+        Bone.Name        = FName("Root");
+        Bone.ParentIndex = INDEX_NONE;
+        Skeleton.Bones.push_back(Bone);
+        Skeleton.BoneNameToIndex[Bone.Name] = 0;
+    }
+
+    // One play-once clip player, reported the way the state machine node records a state.
+    struct FTestState
+    {
+        uint16 PoseRegister = 0;
+        uint16 ClockSlotFirst = 0;
+        uint16 ClockSlotEnd = 0;
+        uint16 ClockSlot = 0;
+    };
+
+    FTestState CompilePlayOnceState(FAnimationGraphCompiler& Compiler, CAnimation* Clip)
+    {
+        FTestState Out;
+        Out.ClockSlotFirst = (uint16)Compiler.GetClockSlots().size();
+        Out.ClockSlot      = Compiler.AllocClockSlot();
+
+        const uint16 SpeedReg    = Compiler.EmitLoadConst(1.0f);
+        const uint16 LoopModeReg = Compiler.EmitLoadConst((float)EClipLoopMode::PlayOnce);
+        const uint16 ClipIndex   = Compiler.AddClip(Clip);
+
+        uint16 FinishedReg = 0;
+        const uint16 TimeReg = Compiler.EmitAdvanceClock(Out.ClockSlot, SpeedReg, ClipIndex, LoopModeReg, FinishedReg);
+
+        Out.PoseRegister  = Compiler.EmitSampleAnim(ClipIndex, TimeReg);
+        Out.ClockSlotEnd  = (uint16)Compiler.GetClockSlots().size();
+        return Out;
+    }
+}
+
+// Clocks advance while a state is inactive, so a finished play-once must be wound back to replay.
+TEST(AnimationStateMachine, PlayOnceStateRestartsOnReEntry)
+{
+    CAnimation* OneShotClip = MakeStateClip(1.0f);
+    CAnimation* IdleClip    = MakeStateClip(1.0f);
+
+    FAnimationGraphCompiler Compiler;
+    const FTestState OneShot = CompilePlayOnceState(Compiler, OneShotClip);
+    const FTestState Idle    = CompilePlayOnceState(Compiler, IdleClip);
+
+    FAnimGraphStateMachine Machine;
+    Machine.EntryState          = 0;
+    Machine.StatePoseRegisters  = { OneShot.PoseRegister, Idle.PoseRegister };
+    Machine.ClockSlots          = Compiler.GetClockSlots();
+    Machine.StateClockSlotFirst = { OneShot.ClockSlotFirst, Idle.ClockSlotFirst };
+    Machine.StateClockSlotEnd   = { OneShot.ClockSlotEnd, Idle.ClockSlotEnd };
+    Machine.CurrentStateSlot    = Compiler.AllocStateSlot();
+    Machine.FromStateSlot       = Compiler.AllocStateSlot();
+    Machine.TimeInStateSlot     = Compiler.AllocStateSlot();
+    Machine.DurationSlot        = Compiler.AllocStateSlot();
+
+    FAnimGraphTransition ToIdle;
+    ToIdle.FromState          = 0;
+    ToIdle.ToState            = 1;
+    ToIdle.ConditionParameter = FName("Go");
+    ToIdle.Compare            = EAnimTransitionCompare::Greater;
+    ToIdle.CompareValue       = 0.5f;
+    ToIdle.BlendDuration      = 0.0f;
+    Machine.Transitions.push_back(ToIdle);
+
+    FAnimGraphTransition BackToOneShot = ToIdle;
+    BackToOneShot.FromState = 1;
+    BackToOneShot.ToState   = 0;
+    BackToOneShot.Compare   = EAnimTransitionCompare::Less;
+    Machine.Transitions.push_back(BackToOneShot);
+
+    const int32 GoParam = Compiler.AddParameter(FName("Go"), EAnimGraphParamType::Float, 0.0f);
+    Compiler.EmitOutput(Compiler.EmitEvalStateMachine(Move(Machine)));
+
+    CAnimationGraph* Graph = NewObject<CAnimationGraph>();
+    Compiler.BuildGraph(Graph);
+
+    FSkeletonResource Skeleton;
+    MakeOneBoneSkeleton(Skeleton);
+
+    FAnimGraphVMState State;
+    FAnimTaskList Tasks;
+    FAnimGraphRootMotion RootMotion;
+
+    // Play the one-shot out past its duration.
+    for (int32 Tick = 0; Tick < 30; ++Tick)
+    {
+        FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    }
+    EXPECT_NEAR(State.StateSlots[OneShot.ClockSlot], 1.0f, 1e-4f) << "clip should have clamped at its end";
+
+    // Leave it. Its clock is wound back while it is not the current state.
+    State.Parameters[GoParam] = 1.0f;
+    for (int32 Tick = 0; Tick < 3; ++Tick)
+    {
+        FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    }
+    EXPECT_NEAR(State.StateSlots[OneShot.ClockSlot], 0.0f, 1e-4f) << "inactive state's clock must not run on";
+
+    // Re-enter: the clip plays from the top rather than resuming at its finished end.
+    State.Parameters[GoParam] = 0.0f;
+    FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    EXPECT_NEAR(State.StateSlots[OneShot.ClockSlot], 0.05f, 1e-4f) << "re-entry must restart the clip";
+}
+
+// A play-once state hands over on dwell time, so no gameplay code needs to know the clip's length.
+TEST(AnimationStateMachine, TimeInStateTransitionFiresAfterItsDwellTime)
+{
+    CAnimation* FirstClip  = MakeStateClip(1.0f);
+    CAnimation* SecondClip = MakeStateClip(1.0f);
+
+    FAnimationGraphCompiler Compiler;
+    const FTestState First  = CompilePlayOnceState(Compiler, FirstClip);
+    const FTestState Second = CompilePlayOnceState(Compiler, SecondClip);
+
+    FAnimGraphStateMachine Machine;
+    Machine.EntryState          = 0;
+    Machine.StatePoseRegisters  = { First.PoseRegister, Second.PoseRegister };
+    Machine.ClockSlots          = Compiler.GetClockSlots();
+    Machine.StateClockSlotFirst = { First.ClockSlotFirst, Second.ClockSlotFirst };
+    Machine.StateClockSlotEnd   = { First.ClockSlotEnd, Second.ClockSlotEnd };
+    Machine.CurrentStateSlot    = Compiler.AllocStateSlot();
+    Machine.FromStateSlot       = Compiler.AllocStateSlot();
+    Machine.TimeInStateSlot     = Compiler.AllocStateSlot();
+    Machine.DurationSlot        = Compiler.AllocStateSlot();
+
+    FAnimGraphTransition WhenDone;
+    WhenDone.FromState       = 0;
+    WhenDone.ToState         = 1;
+    WhenDone.ConditionSource = EAnimTransitionSource::TimeInState;
+    WhenDone.Compare         = EAnimTransitionCompare::GreaterEqual;
+    WhenDone.CompareValue    = 0.3f;
+    WhenDone.BlendDuration   = 0.0f;
+    Machine.Transitions.push_back(WhenDone);
+
+    const uint16 CurrentStateSlot = Machine.CurrentStateSlot;
+    Compiler.EmitOutput(Compiler.EmitEvalStateMachine(Move(Machine)));
+
+    CAnimationGraph* Graph = NewObject<CAnimationGraph>();
+    Compiler.BuildGraph(Graph);
+
+    FSkeletonResource Skeleton;
+    MakeOneBoneSkeleton(Skeleton);
+
+    FAnimGraphVMState State;
+    FAnimTaskList Tasks;
+    FAnimGraphRootMotion RootMotion;
+
+    for (int32 Tick = 0; Tick < 5; ++Tick)
+    {
+        FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    }
+    EXPECT_NEAR(State.StateSlots[CurrentStateSlot], 0.0f, 1e-4f) << "0.25s in, the dwell time is not up";
+
+    for (int32 Tick = 0; Tick < 3; ++Tick)
+    {
+        FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    }
+    EXPECT_NEAR(State.StateSlots[CurrentStateSlot], 1.0f, 1e-4f) << "past 0.3s it must have moved on";
+}
+
+// A reset walking raw slots would zero the inner machine's current state every frame.
+TEST(AnimationStateMachine, NestedMachineKeepsItsStateWhileItsOwnerIsInactive)
+{
+    FAnimationGraphCompiler Compiler;
+
+    const FTestState InnerIdle   = CompilePlayOnceState(Compiler, MakeStateClip(1.0f));
+    const FTestState InnerMoving = CompilePlayOnceState(Compiler, MakeStateClip(1.0f));
+
+    FAnimGraphStateMachine Inner;
+    Inner.EntryState          = 0;
+    Inner.StatePoseRegisters  = { InnerIdle.PoseRegister, InnerMoving.PoseRegister };
+    Inner.ClockSlots          = Compiler.GetClockSlots();
+    Inner.StateClockSlotFirst = { InnerIdle.ClockSlotFirst, InnerMoving.ClockSlotFirst };
+    Inner.StateClockSlotEnd   = { InnerIdle.ClockSlotEnd, InnerMoving.ClockSlotEnd };
+    Inner.CurrentStateSlot    = Compiler.AllocStateSlot();
+    Inner.FromStateSlot       = Compiler.AllocStateSlot();
+    Inner.TimeInStateSlot     = Compiler.AllocStateSlot();
+    Inner.DurationSlot        = Compiler.AllocStateSlot();
+
+    FAnimGraphTransition ToInnerMoving;
+    ToInnerMoving.FromState          = 0;
+    ToInnerMoving.ToState            = 1;
+    ToInnerMoving.ConditionParameter = FName("InnerGo");
+    ToInnerMoving.Compare            = EAnimTransitionCompare::Greater;
+    ToInnerMoving.CompareValue       = 0.5f;
+    ToInnerMoving.BlendDuration      = 0.0f;
+    Inner.Transitions.push_back(ToInnerMoving);
+
+    const uint16 InnerCurrentStateSlot = Inner.CurrentStateSlot;
+    const uint16 InnerPose = Compiler.EmitEvalStateMachine(Move(Inner));
+
+    const FTestState Airborne = CompilePlayOnceState(Compiler, MakeStateClip(1.0f));
+
+    FAnimGraphStateMachine Outer;
+    Outer.EntryState          = 0;
+    Outer.StatePoseRegisters  = { InnerPose, Airborne.PoseRegister };
+    Outer.ClockSlots          = Compiler.GetClockSlots();
+    Outer.StateClockSlotFirst = { InnerIdle.ClockSlotFirst, Airborne.ClockSlotFirst };
+    Outer.StateClockSlotEnd   = { InnerMoving.ClockSlotEnd, Airborne.ClockSlotEnd };
+    Outer.CurrentStateSlot    = Compiler.AllocStateSlot();
+    Outer.FromStateSlot       = Compiler.AllocStateSlot();
+    Outer.TimeInStateSlot     = Compiler.AllocStateSlot();
+    Outer.DurationSlot        = Compiler.AllocStateSlot();
+
+    FAnimGraphTransition ToAirborne;
+    ToAirborne.FromState          = 0;
+    ToAirborne.ToState            = 1;
+    ToAirborne.ConditionParameter = FName("Airborne");
+    ToAirborne.Compare            = EAnimTransitionCompare::Greater;
+    ToAirborne.CompareValue       = 0.5f;
+    ToAirborne.BlendDuration      = 0.0f;
+    Outer.Transitions.push_back(ToAirborne);
+
+    FAnimGraphTransition BackToGrounded = ToAirborne;
+    BackToGrounded.FromState = 1;
+    BackToGrounded.ToState   = 0;
+    BackToGrounded.Compare   = EAnimTransitionCompare::Less;
+    Outer.Transitions.push_back(BackToGrounded);
+
+    const int32 InnerGoParam  = Compiler.AddParameter(FName("InnerGo"), EAnimGraphParamType::Float, 0.0f);
+    const int32 AirborneParam = Compiler.AddParameter(FName("Airborne"), EAnimGraphParamType::Float, 0.0f);
+    Compiler.EmitOutput(Compiler.EmitEvalStateMachine(Move(Outer)));
+
+    CAnimationGraph* Graph = NewObject<CAnimationGraph>();
+    Compiler.BuildGraph(Graph);
+
+    FSkeletonResource Skeleton;
+    MakeOneBoneSkeleton(Skeleton);
+
+    FAnimGraphVMState State;
+    FAnimTaskList Tasks;
+    FAnimGraphRootMotion RootMotion;
+
+    // Drive the inner machine into its second state while its owner is active.
+    FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    State.Parameters[InnerGoParam] = 1.0f;
+    FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    EXPECT_NEAR(State.StateSlots[InnerCurrentStateSlot], 1.0f, 1e-4f) << "inner machine should have moved on";
+
+    // Leave the owning state. The inner machine's current state must be left exactly where it was.
+    State.Parameters[AirborneParam] = 1.0f;
+    for (int32 Tick = 0; Tick < 5; ++Tick)
+    {
+        FAnimationGraphVM::BuildTasks(Graph, &Skeleton, 0.05f, State, Tasks, RootMotion);
+    }
+    EXPECT_NEAR(State.StateSlots[InnerCurrentStateSlot], 1.0f, 1e-4f)
+        << "an inactive owner must not reset its nested machine";
+}


### PR DESCRIPTION
Three changes, all on the animation graph's transition path.

  Inertialization overshoot. InertCapture forced the offset quaternion to the
  shortest arc but not the previous offset it differences against. When that one
  landed in the opposite hemisphere, QuatAngleAbout read a full turn away, and
  the velocity estimate gained a spurious 2*pi/dt term. The decay curve honoured
  it, threw the bone wide, then reeled it back over the blend. Limbs swung out
  and snapped back on every transition. Nothing canonicalizes quaternion signs
  anywhere in this pipeline, so a few bones lost the toss each time.

  Play-once states never replayed. Every state's clock advances each update
  whether or not the state is active. A state that ran to its end therefore
  stayed finished forever. Each state machine now records the clock slots its
  states own and winds the inactive ones back to zero. Clocks only: a nested
  machine's bookkeeping slots sit inside its owning state's blend tree, and
  zeroing those re-ran the inner machine's transitions every frame and
  re-captured its inertializer.

  Transitions can read dwell time. FAnimGraphTransition::ConditionSource picks
  between a named parameter and TimeInState, the seconds spent in the current
  state. A play-once state can now hand over when it ends, without gameplay code
  having to know the clip's length. It reuses the timer slot the state machine
  already allocated and never read.

  Two version entries. Existing graphs load and recompile on next open; until
  they do, they keep the old behaviour rather than misparsing.