### PR TITLE
Fix cached pose dependency issues

### DIFF
--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphCompiler.h
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphCompiler.h
@@ -131,6 +131,8 @@ namespace Lumina
             return true;
         }
 
+        const THashMap<FName, uint16>& GetCachedPoses() const { return CachedPoses; }
+
         uint16 EmitSavePoseSnapshot(uint16 SrcPoseReg, uint16 RequestReg, uint16 SnapshotIndex);
         uint16 EmitLoadPoseSnapshot(uint16 SnapshotIndex);
 

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphNodeGraph.cpp
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphNodeGraph.cpp
@@ -140,32 +140,99 @@ namespace Lumina
             return false;
         }
 
-        // Cached pose branches emit ahead of everything else, so a state machine compiled later in this
-        // walk can resolve a Use Cached Pose sitting inside one of its states.
-        TVector<CEdGraphNode*> CachedPoseNodes;
-        CEdGraphNode* CyclicCachedPoseNode = GraphAlgorithms::TopologicalSortFromRoots(Nodes, CachedPoseNodes, [](CEdGraphNode* Node)
+        // A Save branch can read another cache from inside a nested state graph, which the pin-level
+        // sort cannot see. So order the Save nodes by that dependency and emit one branch at a time.
+        TVector<CAnimGraphNode_SaveCachedPose*> PendingSaves;
+        for (CEdGraphNode* Node : Nodes)
         {
-            return Cast<CAnimGraphNode_SaveCachedPose>(Node) != nullptr;
-        });
-
-        if (CyclicCachedPoseNode != nullptr)
-        {
-            EdNodeGraph::FError Error;
-            Error.Name        = "Cyclic";
-            Error.Description = "Cycle detected feeding a Save Cached Pose node! Graph must be acyclic.";
-            Error.Node        = CyclicCachedPoseNode;
-            Compiler.AddError(Error);
-            return false;
+            if (CAnimGraphNode_SaveCachedPose* Save = Cast<CAnimGraphNode_SaveCachedPose>(Node))
+            {
+                PendingSaves.push_back(Save);
+            }
         }
 
         THashSet<CEdGraphNode*> EmittedNodes;
-        for (CEdGraphNode* Node : CachedPoseNodes)
+        THashSet<FName> WrittenCaches;
+
+        while (!PendingSaves.empty())
         {
-            if (CAnimGraphNode* AnimNode = Cast<CAnimGraphNode>(Node))
+            int32 ReadyIndex = -1;
+            for (int32 i = 0; i < (int32)PendingSaves.size(); ++i)
             {
-                AnimNode->GenerateBytecode(Compiler);
-                EmittedNodes.insert(Node);
+                THashSet<CEdGraphNode*> BranchNodes;
+                GraphAlgorithms::CollectReachableFromRoot(PendingSaves[i], BranchNodes);
+
+                THashSet<FName> ReadCaches;
+                CollectReadCacheNames(BranchNodes, ReadCaches);
+
+                bool bWaiting = false;
+                for (const FName& ReadCache : ReadCaches)
+                {
+                    if (WrittenCaches.find(ReadCache) != WrittenCaches.end())
+                    {
+                        continue;
+                    }
+
+                    for (CAnimGraphNode_SaveCachedPose* Other : PendingSaves)
+                    {
+                        if (Other != PendingSaves[i] && Other->CacheName == ReadCache)
+                        {
+                            bWaiting = true;
+                            break;
+                        }
+                    }
+
+                    if (bWaiting)
+                    {
+                        break;
+                    }
+                }
+
+                if (!bWaiting)
+                {
+                    ReadyIndex = i;
+                    break;
+                }
             }
+
+            // Every remaining Save waits on another, so let the Use node report the circular read.
+            if (ReadyIndex == -1)
+            {
+                ReadyIndex = 0;
+            }
+
+            CAnimGraphNode_SaveCachedPose* ReadySave = PendingSaves[ReadyIndex];
+            PendingSaves.erase(PendingSaves.begin() + ReadyIndex);
+
+            TVector<CEdGraphNode*> BranchOrder;
+            CEdGraphNode* CyclicCachedPoseNode = GraphAlgorithms::TopologicalSortFromRoot(Nodes, BranchOrder,
+                [ReadySave](CEdGraphNode* Node) { return Node == ReadySave; });
+
+            if (CyclicCachedPoseNode != nullptr)
+            {
+                EdNodeGraph::FError Error;
+                Error.Name        = "Cyclic";
+                Error.Description = "Cycle detected feeding a Save Cached Pose node! Graph must be acyclic.";
+                Error.Node        = CyclicCachedPoseNode;
+                Compiler.AddError(Error);
+                return false;
+            }
+
+            for (CEdGraphNode* Node : BranchOrder)
+            {
+                if (EmittedNodes.find(Node) != EmittedNodes.end())
+                {
+                    continue;
+                }
+
+                if (CAnimGraphNode* AnimNode = Cast<CAnimGraphNode>(Node))
+                {
+                    AnimNode->GenerateBytecode(Compiler);
+                    EmittedNodes.insert(Node);
+                }
+            }
+
+            WrittenCaches.insert(ReadySave->CacheName);
         }
 
         // SortedNodes is dependency-ordered, so each node's input registers exist by the time it emits.
@@ -196,6 +263,53 @@ namespace Lumina
         }
 
         return true;
+    }
+
+    void CAnimationGraphNodeGraph::CollectReadCacheNames(const THashSet<CEdGraphNode*>& SubtreeNodes, THashSet<FName>& OutNames)
+    {
+        for (CEdGraphNode* Node : SubtreeNodes)
+        {
+            if (CAnimGraphNode_UseCachedPose* Use = Cast<CAnimGraphNode_UseCachedPose>(Node))
+            {
+                OutNames.insert(Use->CacheName);
+            }
+
+            CAnimGraphNode_StateMachine* Machine = Cast<CAnimGraphNode_StateMachine>(Node);
+            if (Machine == nullptr)
+            {
+                continue;
+            }
+
+            CAnimStateMachineGraph* SMGraph = Machine->StateMachineGraph.Get();
+            if (SMGraph == nullptr)
+            {
+                continue;
+            }
+
+            for (CEdGraphNode* SubNode : SMGraph->Nodes)
+            {
+                if (CAnimGraphNode_State* State = Cast<CAnimGraphNode_State>(SubNode))
+                {
+                    CollectReadCacheNamesInGraph(State->BlendTree.Get(), OutNames);
+                }
+            }
+        }
+    }
+
+    void CAnimationGraphNodeGraph::CollectReadCacheNamesInGraph(CAnimationGraphNodeGraph* Graph, THashSet<FName>& OutNames)
+    {
+        if (Graph == nullptr)
+        {
+            return;
+        }
+
+        THashSet<CEdGraphNode*> GraphNodes;
+        for (CEdGraphNode* Node : Graph->Nodes)
+        {
+            GraphNodes.insert(Node);
+        }
+
+        CollectReadCacheNames(GraphNodes, OutNames);
     }
 
     void CAnimationGraphNodeGraph::CollectAllParameters(FAnimationGraphCompiler& Compiler)

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphNodeGraph.h
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/AnimationGraphNodeGraph.h
@@ -50,6 +50,10 @@ namespace Lumina
 
     private:
 
+        // Cache names read by Use Cached Pose nodes under these, nested state blend trees included.
+        static void CollectReadCacheNames(const THashSet<CEdGraphNode*>& SubtreeNodes, THashSet<FName>& OutNames);
+        static void CollectReadCacheNamesInGraph(CAnimationGraphNodeGraph* Graph, THashSet<FName>& OutNames);
+
         TObjectPtr<CAnimationGraph> AnimationGraph;
 
         // One-shot guards; not serialized. bSetupDone covers context-free setup; bInitialized covers

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_CachedPose.cpp
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_CachedPose.cpp
@@ -1,5 +1,7 @@
 #include "AnimGraphNode_CachedPose.h"
 #include "UI/Tools/NodeGraph/Animation/AnimationGraphCompiler.h"
+#include "UI/Tools/NodeGraph/EdNodeGraph.h"
+#include "Core/Object/Cast.h"
 
 namespace Lumina
 {
@@ -22,6 +24,26 @@ namespace Lumina
     void CAnimGraphNode_UseCachedPose::BuildNode()
     {
         PosePin = CreateAnimPin("Pose", ENodePinDirection::Output, EAnimPinType::Pose);
+    }
+
+    CEdGraphNode* CAnimGraphNode_UseCachedPose::GetImplicitInputNode() const
+    {
+        CEdNodeGraph* Graph = GetOwningGraph();
+        if (Graph == nullptr || CacheName.IsNone())
+        {
+            return nullptr;
+        }
+
+        for (CEdGraphNode* Node : Graph->Nodes)
+        {
+            CAnimGraphNode_SaveCachedPose* Save = Cast<CAnimGraphNode_SaveCachedPose>(Node);
+            if (Save != nullptr && Save->CacheName == CacheName)
+            {
+                return Save;
+            }
+        }
+
+        return nullptr;
     }
 
     void CAnimGraphNode_UseCachedPose::GenerateBytecode(FAnimationGraphCompiler& Compiler)

--- a/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_CachedPose.h
+++ b/Engine/Editor/Source/UI/Tools/NodeGraph/Animation/Nodes/AnimGraphNode_CachedPose.h
@@ -42,6 +42,9 @@ namespace Lumina
         void BuildNode() override;
         void GenerateBytecode(FAnimationGraphCompiler& Compiler) override;
 
+        // Wireless dependency on the Save node naming this cache, so the sort emits that Save first.
+        CEdGraphNode* GetImplicitInputNode() const override;
+
         FString GetNodeTitleText() const override;
 
         /** Cache read back. Must match the name on the Save Cached Pose node that writes it. */


### PR DESCRIPTION
There was an issue where a PoseA is cached, that is used by another execution chain that eventually gets cached as PoseB, the editor would not recognize the PoseA as being a valid cache pose name and not compile